### PR TITLE
Upgraded wheel and cointoss command, bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ __pycache__
 
 # Misc and bot files
 archive
-wins.json
+wins.yaml
 
 # templates
 .env

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The minimum permissions needed for all commands to work are:
 
 Note that if you wish to use the `/wins view` command, then server members intent must be enabled.
 
-![Image of server member intents setting.](.\docs\server-member-intents.png)
+![Image of server member intents setting.](docs/server-member-intents.png)
 
 Once your bot is added to your server, you are ready to move on.
 
@@ -103,11 +103,11 @@ Adds a member and their associated choice to the wheel's options.
 Usage: 
 
 ```bash
-/wheel add <@member> <choice>
+/wheel add <choice> <@member>
 ```
 
-- *@member:* The member associated with the choice.
 - *choice:* The choice associated with the member.
+- *@member:* The member associated with the choice. Defaults to message author.
 
 ### wheel clear
 
@@ -143,28 +143,29 @@ Usage:
 
 - *clear:* Optional, defaults to True. Specifies whether the wheel's choices will be cleared.
 
-## win commands
+## record commands
 
-### wins reset
+### record reset
 
-Resets the number of wins for all past wheel spins. Must be administrator.
-
-Usage: 
-
-```bash
-/wins reset
-```
-
-### wins view
-
-Shows the current number of wins for all past wheel spin members.
+Resets the record for all past wheel spins. Must be administrator.
 
 Usage: 
 
 ```bash
-/wins view
+/record reset
 ```
 
+### record view
+
+Shows the record for all past wheel spin members.
+
+Usage: 
+
+```bash
+/record view <show_weights>
+```
+
+- *show_weights:* Optional. Shows the weights of each member.
 
 
 # Planned Features

--- a/bot/botinit.py
+++ b/bot/botinit.py
@@ -24,5 +24,3 @@ async def on_ready():
     Prints to console when bot is ready.
     """
     print(f"Logged in as {bot.user}")
-
-

--- a/bot/commands/cointoss.py
+++ b/bot/commands/cointoss.py
@@ -28,23 +28,26 @@ async def cointoss(ctx: mybot.discord.ApplicationContext, num_coins: int = 1):
     if num_coins < 1 or num_coins > MAX_COINS:
         await ctx.respond("Invalid number of coins.", ephemeral=True)
         return
-    
+    embed = mybot.discord.Embed(
+        title = "✨**Wheel Spinner Wins**✨",
+        color = mybot.discord.Color.dark_gold()
+    )
     coin_tosses = [randint(HEADS, TAILS) for x in range(num_coins)]
     
     if num_coins == 1:
-        msg = format(coin_tosses[0])
-        await ctx.respond(msg)
+        embed.description = format(coin_tosses[0])
+        await ctx.respond(embed=embed)
         return
-    msg = ""
+    field = ""
     num_heads = 0
     num_tails = 0
     for i in range(0, num_coins):
         coin = format(coin_tosses[i])
-        msg += f"{i + 1}. {coin}\n"
+        field += f"{i + 1}. {coin}\n"
         if coin_tosses[i] == HEADS:
             num_heads += 1
         else:
             num_tails += 1
-    msg = f"**Heads:** {num_heads}, **Tails:** {num_tails}\n" + msg
-    
-    await ctx.respond(msg)
+    embed.description = f"**Heads:** {num_heads}, **Tails:** {num_tails}\n"
+    embed.add_field(name="Results", value=field)
+    await ctx.respond(embed=embed)

--- a/bot/commands/shutdown.py
+++ b/bot/commands/shutdown.py
@@ -18,6 +18,6 @@ async def shutdown(ctx: mybot.discord.ApplicationContext):
         await ctx.respond(f'Shutting down bot...', ephemeral=True)
         await mybot.bot.close()
     except Exception as e:
-        print("Exception caught: ", e)
+        print(f"Exception caught: {e}")
     finally:
         print('Bot Closed')

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,13 +1,17 @@
 import importlib
 import yaml
 
-config_file = "./bot/resources/config.yaml"
+CONFIG_FILE = "./bot/resources/config.yaml"
 config = {}
 
-with open(config_file, "r") as myYaml:
-    config.update(yaml.load(myYaml, Loader=yaml.SafeLoader))
+try:
+    with open(CONFIG_FILE, "r") as myYaml:
+        config.update(yaml.load(myYaml, Loader=yaml.SafeLoader))
+except Exception as e:
+    print(f"Unable to import file {CONFIG_FILE}. Exception caught: {e}")
 
 # Imports command modules if enabled in config.json
 for setting, enabled in config.items():
     if enabled:
         importlib.import_module(f"bot.commands.{setting}")
+        print(f"Imported command module {setting}.")


### PR DESCRIPTION
Changed win view, wheel view, and cointoss commands to use embeds. Switched from JSON to YAML for wins file since ints were converted to strings in JSON. Added Record class to track user wins and losses. Renamed wins command group to record.

Fixed bug in wheel command which caused win record to be appended instead of
 overwritten. Fixed bug that caused wins file to be empty.